### PR TITLE
Rótulo do campo Município para o singular

### DIFF
--- a/src/app/components/search-form/search-form.component.html
+++ b/src/app/components/search-form/search-form.component.html
@@ -34,7 +34,7 @@
   <app-row [flex]="true" [gap]="16">
     <mat-form-field appearance="fill" class="city-input">
       <mat-icon matPrefix svgIcon="pin-gray"></mat-icon>
-      <mat-label>Municípios</mat-label>
+      <mat-label>Município</mat-label>
       <input
         class="city"
         #cityField


### PR DESCRIPTION
Atualiza o rótulo do campo Município para o singular, já que só é possível escolher uma opção

---

**English**
Update the city field label to singular since it's only possible to choose one option

---

Fix #21 