### PR TITLE
Atualiza os números de cidades da plataforma

### DIFF
--- a/src/assets/pages/home.json
+++ b/src/assets/pages/home.json
@@ -15,11 +15,11 @@
             "width": 50
           }
         },
-        "count": 16,
+        "count": 21,
         "text": "Cidades já na plataforma"
       },
       {
-        "count": 2226,
+        "count": 2420,
         "icon": {
           "file": "search",
           "height": 76,
@@ -41,7 +41,7 @@
             "width": 50
           }
         },
-        "count": 597,
+        "count": 600,
         "height": 76,
         "width": 76,
         "text": "Cidades já foram mapeadas pelo censo"
@@ -60,7 +60,7 @@
       {
         "icon": { "file": "gift", "height": 56, "width": 40 },
         "title": "Nossa próxima meta",
-        "text": "Hoje, já poderíamos ter 2226 cidades na plataforma e você pode nos ajudar a chegar lá",
+        "text": "Hoje, já poderíamos ter 2420 cidades na plataforma e você pode nos ajudar a chegar lá",
         "actions": [
           {
             "text": "Doe",

--- a/src/assets/pages/notifications.json
+++ b/src/assets/pages/notifications.json
@@ -1,56 +1,46 @@
 {
-  "list": [{
-    "title": "Nova atualização!",
-    "content": "A cidade de Brasilia (DF) foi adicionada à plataforma!",
-    "updatedAt": "2022/03/25",
-    "isNew": true
-  },
-  {
-    "title": "Nova atualização!",
-    "content": "A cidade de Recife (PE) foi adicionada à plataforma!",
-    "updatedAt": "2022/03/25",
-    "isNew": true
-  },
-  {
-    "title": "Nova atualização!",
-    "content": "A cidade de Caxias (MA) foi adicionada à plataforma!",
-    "updatedAt": "2022/03/25",
-    "isNew": true
-  },
-  {
-    "title": "Nova atualização!",
-    "content": "A cidade de Jaboatão dos Guararapes (PE) foi adicionada à plataforma!",
-    "updatedAt": "2022/03/25",
-    "isNew": true
-  },
-  {
-    "title": "Nova atualização!",
-    "content": "A cidade de Sumaré (SP) foi adicionada à plataforma!",
-    "updatedAt": "2022/03/25",
-    "isNew": true
-  },
-  {
-    "title": "Nova atualização!",
-    "content": "A cidade de Cuiabá (MT) foi adicionada à plataforma!",
-    "updatedAt": "2021/10/20",
-    "isNew": false
-  },
-  {
-    "title": "Nova atualização!",
-    "content": "A cidade de Belo Horizonte (MG) foi adicionada à plataforma!",
-    "updatedAt": "2021/10/20",
-    "isNew": false
-  },
-  {
-    "title": "Nova atualização!",
-    "content": "A cidade de Belém (PA) foi adicionada à plataforma!",
-    "updatedAt": "2021/10/20",
-    "isNew": false
-  },
-  {
-    "title": "Nova atualização!",
-    "content": "A cidade de Feira de Santana (BA) foi adicionada à plataforma!",
-    "updatedAt": "2021/10/20",
-    "isNew": false
-  }]
+  "list": [
+    {
+      "title": "Nova atualização!",
+      "content": "A cidade de Brasilia (DF) foi adicionada à plataforma!",
+      "updatedAt": "2022/03/25",
+      "isNew": true
+    },
+    {
+      "title": "Nova atualização!",
+      "content": "A cidade de Recife (PE) foi adicionada à plataforma!",
+      "updatedAt": "2022/03/25",
+      "isNew": true
+    },
+    {
+      "title": "Nova atualização!",
+      "content": "A cidade de Caxias (MA) foi adicionada à plataforma!",
+      "updatedAt": "2022/03/25",
+      "isNew": true
+    },
+    {
+      "title": "Nova atualização!",
+      "content": "A cidade de Jaboatão dos Guararapes (PE) foi adicionada à plataforma!",
+      "updatedAt": "2022/03/25",
+      "isNew": true
+    },
+    {
+      "title": "Nova atualização!",
+      "content": "A cidade de Sumaré (SP) foi adicionada à plataforma!",
+      "updatedAt": "2022/03/25",
+      "isNew": true
+    },
+    {
+      "title": "Novas 4 cidades!",
+      "content": "As cidades de Belém (PA), Belo Horizonte (MG), Cuiabá (MT) e Feira de Santana (BA) foram adicionadas à plataforma!",
+      "updatedAt": "2021/10/20",
+      "isNew": false
+    },
+    {
+      "title": "A plataforma do Querido Diário foi lançada com 12 capitais!",
+      "content": "As cidades de Boa Vista (RR), Campo Grande (MS), Florianópolis (SC), Goiânia (GO), João Pessoa (PB), Maceió (AL), Manaus (AM), Natal (RN), Palmas (TO), Rio de Janeiro (RJ), Salvador (BA) e Teresina (PI) já estão disponíveis para consulta!",
+      "updatedAt": "2021/07/20",
+      "isNew": false
+    }
+  ]
 }

--- a/src/assets/pages/notifications.json
+++ b/src/assets/pages/notifications.json
@@ -1,26 +1,56 @@
 {
-   "list": [{
+  "list": [{
+    "title": "Nova atualização!",
+    "content": "A cidade de Brasilia (DF) foi adicionada à plataforma!",
+    "updatedAt": "2022/03/25",
+    "isNew": true
+  },
+  {
+    "title": "Nova atualização!",
+    "content": "A cidade de Recife (PE) foi adicionada à plataforma!",
+    "updatedAt": "2022/03/25",
+    "isNew": true
+  },
+  {
+    "title": "Nova atualização!",
+    "content": "A cidade de Caxias (MA) foi adicionada à plataforma!",
+    "updatedAt": "2022/03/25",
+    "isNew": true
+  },
+  {
+    "title": "Nova atualização!",
+    "content": "A cidade de Jaboatão dos Guararapes (PE) foi adicionada à plataforma!",
+    "updatedAt": "2022/03/25",
+    "isNew": true
+  },
+  {
+    "title": "Nova atualização!",
+    "content": "A cidade de Sumaré (SP) foi adicionada à plataforma!",
+    "updatedAt": "2022/03/25",
+    "isNew": true
+  },
+  {
     "title": "Nova atualização!",
     "content": "A cidade de Cuiabá (MT) foi adicionada à plataforma!",
     "updatedAt": "2021/10/20",
-    "isNew": true
+    "isNew": false
   },
   {
     "title": "Nova atualização!",
     "content": "A cidade de Belo Horizonte (MG) foi adicionada à plataforma!",
     "updatedAt": "2021/10/20",
-    "isNew": true
+    "isNew": false
   },
   {
     "title": "Nova atualização!",
     "content": "A cidade de Belém (PA) foi adicionada à plataforma!",
     "updatedAt": "2021/10/20",
-    "isNew": true
+    "isNew": false
   },
   {
     "title": "Nova atualização!",
     "content": "A cidade de Feira de Santana (BA) foi adicionada à plataforma!",
     "updatedAt": "2021/10/20",
-    "isNew": true
+    "isNew": false
   }]
 }


### PR DESCRIPTION
Este PR:
- Atualiza o nível de 5 cidades: Sumaré (SP), Brasília (DF), Caxias (MA), Jaboatão dos Guararapes (PE), Recife (PE)
- Atualiza o contador de cidades em produção, o contador de cidades raspáveis, o contador de cobertura do censo
- Atualiza o dropdown de notificações