### PR TITLE
Modifica termo na busca por query na API do QD

### DIFF
--- a/src/app/gazette.service.ts
+++ b/src/app/gazette.service.ts
@@ -76,7 +76,7 @@ export class GazetteService {
     }?`;
 
     if (term) {
-      url += `keywords=${term}&pre_tags=%3Cb%3E&post_tags=%3C%2Fb%3E&fragment_size=500&`;
+      url += `querystring=${term}&pre_tags=%3Cb%3E&post_tags=%3C%2Fb%3E&fragment_size=500&`;
     }
 
     if (since) {


### PR DESCRIPTION
A API utilizava o campo `keywords` para a busca e agora utliza o campo `querystring`.