### PR TITLE
Adiciona painel na página de cidades disponíveis

### DIFF
--- a/src/app/modules/pages/available-cities/available-cities.component.html
+++ b/src/app/modules/pages/available-cities/available-cities.component.html
@@ -2,17 +2,23 @@
 <ng-container *ngIf="content$ | async as content"> 
     <app-container theme="light">
         <div class="container-inner" [style.paddingTOP]="'0px'">
-            <app-column [gap]="10">
-                <h1>{{ content.title }}</h1>
-                <p class="cities-text" [innerHtml]="content.text"></p>
-                <app-column>
-                  <div class="cities-flex">
-                    <ng-container>
-                      <div class="avaliable-city" *ngFor="let city of cities">{{ city.territory_name }} ({{city.state_code}})</div>
-                    </ng-container>
-                  </div>
-                </app-column>
+          <div class="coverage-dashboard" fxHide fxShow.gt-md>
+            <iframe width="1020" height="700" src="https://datastudio.google.com/embed/reporting/10838efc-aba4-4916-b9e6-c84f6f0688f9/page/E957C"
+            frameborder="0" 
+            style="border:0" allowfullscreen>
+            </iframe>
+          </div>
+          <app-column [gap]="10">
+            <h1>{{ content.title }}</h1>
+            <p class="cities-text" [innerHtml]="content.text"></p>
+            <app-column>
+              <div class="cities-flex">
+                <ng-container>
+                  <div class="avaliable-city" *ngFor="let city of cities">{{ city.territory_name }} ({{city.state_code}})</div>
+                </ng-container>
+              </div>
             </app-column>
+          </app-column>
         </div>
     </app-container>
 </ng-container>

--- a/src/app/modules/pages/available-cities/available-cities.component.sass
+++ b/src/app/modules/pages/available-cities/available-cities.component.sass
@@ -14,3 +14,8 @@
 .cities-flex
   display: flex
   flex-wrap: wrap
+
+.coverage-dashboard
+  position: relative
+  height: 50%
+  overflow: hidden

--- a/src/styles.sass
+++ b/src/styles.sass
@@ -81,7 +81,6 @@ mat-spinner
 .dark
   background-color: #351E41
 
-
 .light
   background-color: #F3E9E9
   color: #5E3F8E !important


### PR DESCRIPTION
Este PR adiciona  um painel embed da ferramenta datastudio da Google. Para isso:
- Adapta o componente CSS da página available-cities para reconhecer a classe `google-data-studio`
- Utiliza a classe embeddando o link para o painel
- Como o painel não é responsivo, a div está configurada para não aparecer quando detecta tamanhos pequenos de tela (recurso disponível por angular/flex-layout)