### PR TITLE
Fix: cities not showing up on desktop - #102

### DIFF
--- a/src/app/modules/layout/container/container.component.sass
+++ b/src/app/modules/layout/container/container.component.sass
@@ -4,6 +4,7 @@
 .container
   width: 1220px
   padding: rem(84) 0
+  height: 100%
 
 .container-inner
   width: 1220px

--- a/src/app/modules/pages/available-cities/available-cities.component.html
+++ b/src/app/modules/pages/available-cities/available-cities.component.html
@@ -1,7 +1,7 @@
 
 <ng-container *ngIf="content$ | async as content"> 
     <app-container theme="light">
-        <div class="container-inner" [style.paddingTOP]="'0px'">
+        <div class="container-inner" [style.paddingTOP]="'0px'" fxLayout="column" fxLayoutGap="24px">
           <div class="coverage-dashboard" fxHide fxShow.gt-md>
             <iframe width="1020" height="700" src="https://datastudio.google.com/embed/reporting/10838efc-aba4-4916-b9e6-c84f6f0688f9/page/E957C"
             frameborder="0" 


### PR DESCRIPTION
Corrige o erro de cidades sendo cortadas na letra S no desktop (#102) . Ocorria pela tabela extrapolar o tamanho do container, corrigido com um simples `height: 100%`. Por se tratar de um componente presente em diferentes lugares do site, foram conferidas todas as páginas para certificar que nada mudou.

Por fim, adicionei ainda margem entre o dashboard e o container de texto, visto que o largo espaçamento que havia antes deixou de existir com a alteração no container.