### PR TITLE
Corrige a página inicial de busca do QD Edu

### DIFF
--- a/src/app/modules/pages/area-education/search/search.component.ts
+++ b/src/app/modules/pages/area-education/search/search.component.ts
@@ -64,7 +64,6 @@ export class SearchEducationComponent implements OnInit {
         post_tags: "</b>",
       } as GazetteFilters;
       if(Object.keys(Object.keys(this.filters).filter(key => !!this.filters[key])).length > 1) {
-        this.isLoading = true;
         this.onChangeFilters(this.filters);
       }
     }).unsubscribe();


### PR DESCRIPTION
Corrige a página inicial de busca do QD Edu para exibir uma imagem estática indicando que o usuário pode realizar uma busca.
Resolve #195

**Português (BR)** | [English (US)](?quick_pull=1&template=PULL_REQUEST-en-US.md)

## Comunidade

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/okfn-brasil/querido-diario-frontend/blob/main/docs/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://github.com/okfn-brasil/querido-diario-comunidade/blob/main/.github/CODE_OF_CONDUCT.md).

## Tipo de alteração

* [x] 🐞 Correção de problema
* [ ] ✨ Melhoria ou nova funcionalidade
* [ ] 📰 Nova postagem no blog

## Issues relacionadas
Issues que são relacionadas a esta Pull Request.
#195 
<!--
Considere abrir uma issue relacionada à alteração ou conversar com alguém para que seja aberta e assim termos mapeadas as alterações.

Caso esta Pull Request resolva uma ou mais issues existentes, vincule-as com uma palavra-chave para que ao ser mergeada, a issue seja fechada.

Ex.: Resolve #123

Mais informações: https://docs.github.com/pt/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Validação

* [x] Validei a alteração no link gerado pelo bot da Netlify (Deploy Preview/Preview on mobile)
* [x] Validei o Layout responsivo (desktop/mobile) após a implementação
* [x] Verifiquei o registro do deploy (Latest deploy log) e nenhum novo alerta ou erro foi adicionado

## Evidências
Anexe evidências do antes e do depois da alteração (quando necessário).

**Antes:**
![Antes](https://github.com/okfn-brasil/querido-diario-frontend/assets/104526833/6c46c3ec-bc8c-4ad7-9579-4d965b37fcbb)

**Depois:**
![image](https://github.com/okfn-brasil/querido-diario-frontend/assets/104526833/8476ea77-3587-403c-9943-29462164452e)

<!-- Você pode arrastar imagens para cá. -->

## Documentação

* [ ] A documentação deste repositório foi atualizada (quando necessário).
* [ ] Esta alteração requer que a documentação externa seja atualizada.
