### PR TITLE
fix: alinhamento do botão de notificação

### DIFF
--- a/src/app/modules/components/header/header.component.ts
+++ b/src/app/modules/components/header/header.component.ts
@@ -82,7 +82,7 @@ export class HeaderComponent implements OnInit {
   }
 
   openNotifications(): void {
-    const left = this.explore.nativeElement.offsetLeft + 144; // important
+    const left = this.explore.nativeElement.offsetLeft + 80; // important
     this.modal.open(NotificationsComponent, {
       width: '414px',
       maxWidth: '100%',

--- a/src/app/modules/components/notifications/notifications.component.sass
+++ b/src/app/modules/components/notifications/notifications.component.sass
@@ -22,7 +22,7 @@
   border-right: 15px solid transparent
   border-bottom: 15px solid #2C1338
   align-self: flex-end
-  margin-right: 41px
+  margin-right: 14px
 
 .date
   margin: 0 !important

--- a/src/app/modules/components/notifications/notifications.component.sass
+++ b/src/app/modules/components/notifications/notifications.component.sass
@@ -22,7 +22,7 @@
   border-right: 15px solid transparent
   border-bottom: 15px solid #2C1338
   align-self: flex-end
-  margin-right: 14px
+  margin-right: 0.8rem
 
 .date
   margin: 0 !important


### PR DESCRIPTION
**Português (BR)** | [English (US)](?quick_pull=1&template=PULL_REQUEST-en-US.md)

Corrige o alinhamento da seta indicadora com o ícone de notificações.

## Comunidade

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/okfn-brasil/querido-diario-frontend/blob/main/docs/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://github.com/okfn-brasil/querido-diario-comunidade/blob/main/.github/CODE_OF_CONDUCT.md).

## Tipo de alteração

* [x] 🐞 Correção de problema
* [ ] ✨ Melhoria ou nova funcionalidade
* [ ] 📰 Nova postagem no blog

## Issues relacionadas
Issues que são relacionadas a esta Pull Request.

[#197](https://github.com/okfn-brasil/querido-diario-frontend/issues/197#issue-1943656692)

<!--
Considere abrir uma issue relacionada à alteração ou conversar com alguém para que seja aberta e assim termos mapeadas as alterações.

Caso esta Pull Request resolva uma ou mais issues existentes, vincule-as com uma palavra-chave para que ao ser mergeada, a issue seja fechada.

Ex.: Resolve #123

Mais informações: https://docs.github.com/pt/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Validação

* [ ] Validei a alteração no link gerado pelo bot da Netlify (Deploy Preview/Preview on mobile)
* [ ] Validei o Layout responsivo (desktop/mobile) após a implementação
* [ ] Verifiquei o registro do deploy (Latest deploy log) e nenhum novo alerta ou erro foi adicionado

## Evidências
Anexe evidências do antes e do depois da alteração (quando necessário).

Antes: 

![image](https://github.com/okfn-brasil/querido-diario-frontend/assets/58270725/224327e8-44a0-4579-9b19-cfad75b193ff)

Depois:

![image](https://github.com/okfn-brasil/querido-diario-frontend/assets/58270725/0aaed6d1-98d0-44be-96d7-df867bcbee22)


<!-- Você pode arrastar imagens para cá. -->

## Documentação

* [ ] A documentação deste repositório foi atualizada (quando necessário).
* [ ] Esta alteração requer que a documentação externa seja atualizada.
