### PR TITLE
feat: add cache on cities service and in home

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -110,8 +110,7 @@ import { ResetPassModalComponent } from './modules/pages/area-education/header/r
 import { AboutComponent as AboutComponentEnUS } from './modules/pages/about-en_US/about.component';
 import { TechComponent as TechComponentEnUS } from './modules/pages/tech-en_US/tech.component';
 import { PrivacyPolicyComponent as PrivacyPolicyComponentEnUS } from './modules/pages/privacy-policy-en_US/privacy-policy.component';
-
-
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 @NgModule({
   declarations: [
@@ -204,6 +203,7 @@ import { PrivacyPolicyComponent as PrivacyPolicyComponentEnUS } from './modules/
     MatCardModule,
     MatAutocompleteModule,
     FormsModule,
+    MatSnackBarModule,
     ReactiveFormsModule,
     MatDatepickerModule,
     MatNativeDateModule,

--- a/src/app/modules/pages/available-cities/available-cities.component.ts
+++ b/src/app/modules/pages/available-cities/available-cities.component.ts
@@ -7,7 +7,7 @@ import { ContentService } from 'src/app/services/content/content.service';
 @Component({
   selector: 'app-available-cities',
   templateUrl: './available-cities.component.html',
-  styleUrls: ['./available-cities.component.sass']
+  styleUrls: ['./available-cities.component.sass'],
 })
 export class AvailableCitiesComponent implements OnInit {
   content$: Observable<any> = of(null);
@@ -16,18 +16,18 @@ export class AvailableCitiesComponent implements OnInit {
 
   constructor(
     private contentService: ContentService,
-    private citiesService: CitiesService,
-    ) {}
+    private citiesService: CitiesService
+  ) {}
 
   ngOnInit(): void {
     this.content$ = this.contentService.find('available-cities');
 
-    this.citiesService.getAll().subscribe(response => {
+    this.citiesService.getAll().subscribe((response) => {
       this.loading = false;
-      this.cities = response.cities.sort((cityA: City, cityB: City) => 
+
+      this.cities = response.cities.sort((cityA: City, cityB: City) =>
         cityA.territory_name.localeCompare(cityB.territory_name)
       );
     });
   }
 }
-

--- a/src/app/modules/pages/home/home.component.ts
+++ b/src/app/modules/pages/home/home.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { Observable, forkJoin, of, pipe } from 'rxjs';
+import { Observable, forkJoin, of } from 'rxjs';
 import { ContentService } from 'src/app/services/content/content.service';
 import { VideoModalComponent } from '../../components/video-modal/video-modal.component';
 import { CitiesService } from 'src/app/services/cities/cities.service';
@@ -13,7 +13,6 @@ import { map } from 'rxjs/operators';
 })
 export class HomeComponent implements OnInit {
   content$: Observable<any> = of(null);
-  newContent$: Observable<any> = of(null);
   numberOfCities = 0;
 
   constructor(
@@ -28,7 +27,7 @@ export class HomeComponent implements OnInit {
       numberOfCities: this.citiesService.getAll(),
     }).pipe(
       map((data) => {
-        data.content.evolution.items[0].count =
+        data.content.evolution.items[0]['count'] =
           data.numberOfCities.cities.length;
         return data.content;
       })

--- a/src/app/modules/pages/home/home.component.ts
+++ b/src/app/modules/pages/home/home.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { Observable, of } from 'rxjs';
+import { Observable, forkJoin, of, pipe } from 'rxjs';
 import { ContentService } from 'src/app/services/content/content.service';
 import { VideoModalComponent } from '../../components/video-modal/video-modal.component';
+import { CitiesService } from 'src/app/services/cities/cities.service';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-home',
@@ -10,16 +12,27 @@ import { VideoModalComponent } from '../../components/video-modal/video-modal.co
   styleUrls: ['./home.component.sass'],
 })
 export class HomeComponent implements OnInit {
-  content$: Observable<any> = of(null)
+  content$: Observable<any> = of(null);
+  newContent$: Observable<any> = of(null);
+  numberOfCities = 0;
 
   constructor(
     private modal: MatDialog,
-    private contentService: ContentService
-  ) {
-  }
+    private contentService: ContentService,
+    private citiesService: CitiesService
+  ) {}
 
   ngOnInit() {
-   this.content$ = this.contentService.find('home');
+    this.content$ = forkJoin({
+      content: this.contentService.find('home'),
+      numberOfCities: this.citiesService.getAll(),
+    }).pipe(
+      map((data) => {
+        data.content.evolution.items[0].count =
+          data.numberOfCities.cities.length;
+        return data.content;
+      })
+    );
   }
 
   openVideo(): void {

--- a/src/app/services/cities/cities.service.ts
+++ b/src/app/services/cities/cities.service.ts
@@ -1,20 +1,25 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, shareReplay } from 'rxjs/operators';
 import { API } from 'src/app/constants';
 
 @Injectable({
   providedIn: 'root',
 })
 export class CitiesService {
+  getAllObservableCache: Observable<any> | null = null;
   constructor(private http: HttpClient) {}
 
   getAll(): Observable<any> {
-    return this.http.get(`${API}/cities?levels=3`).pipe(
-      map((data) => {
-        return data;
-      })
-    );
+    if (!this.getAllObservableCache)
+      this.getAllObservableCache = this.http.get(`${API}/cities?levels=3`).pipe(
+        map((data) => {
+          return data;
+        }),
+        shareReplay(1)
+      );
+
+    return this.getAllObservableCache;
   }
 }

--- a/src/app/services/cities/cities.service.ts
+++ b/src/app/services/cities/cities.service.ts
@@ -1,15 +1,16 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map, shareReplay } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, map, shareReplay } from 'rxjs/operators';
 import { API } from 'src/app/constants';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Injectable({
   providedIn: 'root',
 })
 export class CitiesService {
   getAllObservableCache: Observable<any> | null = null;
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private snackBar: MatSnackBar) {}
 
   getAll(): Observable<any> {
     if (!this.getAllObservableCache)
@@ -17,7 +18,14 @@ export class CitiesService {
         map((data) => {
           return data;
         }),
-        shareReplay(1)
+        shareReplay(1),
+        catchError(() => {
+          this.snackBar.open(
+            'Houve um erro buscando as cidades disponíveis! Tente novamente mais tarde.',
+            'Fechar'
+          );
+          return of({ cities: [] });
+        })
       );
 
     return this.getAllObservableCache;

--- a/src/app/services/cities/cities.service.ts
+++ b/src/app/services/cities/cities.service.ts
@@ -19,7 +19,8 @@ export class CitiesService {
           return data;
         }),
         shareReplay(1),
-        catchError(() => {
+        catchError((error) => {
+          console.error(error);
           this.snackBar.open(
             'Houve um erro buscando as cidades disponíveis! Tente novamente mais tarde.',
             'Fechar'

--- a/src/assets/pages/home.json
+++ b/src/assets/pages/home.json
@@ -15,7 +15,7 @@
             "width": 50
           }
         },
-        "count": 359,  
+        "count": 359,
         "text": "Cidades já na plataforma"
       },
       {
@@ -123,23 +123,97 @@
     {
       "title": "REALIZAÇÃO",
       "icons": [
-        { "file": "logo-OK", "to": "https://ok.org.br/", "target": "_blank", "height": 30, "width": 106 },
-        { "file": "logo-serenata", "to": "https://serenata.ai/", "target": "_blank", "height": 40, "width": 82 },
-        { "file": "logo-embaixadores", "to": "https://embaixadoras.ok.org.br/", "target": "_blank", "height": 18, "width": 116 }
+        {
+          "file": "logo-OK",
+          "to": "https://ok.org.br/",
+          "target": "_blank",
+          "height": 30,
+          "width": 106
+        },
+        {
+          "file": "logo-serenata",
+          "to": "https://serenata.ai/",
+          "target": "_blank",
+          "height": 40,
+          "width": 82
+        },
+        {
+          "file": "logo-embaixadores",
+          "to": "https://embaixadoras.ok.org.br/",
+          "target": "_blank",
+          "height": 18,
+          "width": 116
+        }
       ]
     },
     {
       "title": "APOIO",
       "icons": [
-        { "file": "logo-Ilda", "to": "https://idatosabiertos.org/", "target": "_blank", "height": 17, "width": 52 },
-        { "file": "logo_empatia", "to": "https://www.empatia.la/", "target": "_blank", "height": 16, "width": 87 },
-        { "file": "logo-jurema", "to": "https://www.jurema.la/", "target": "_blank", "height": 18, "width": 80 },
-        { "file": "logo-digitalocean", "to": "https://www.digitalocean.com/", "target": "_blank", "height": 18, "width": 110},
-        { "file": "logo-fiocruz", "to": "https://pcdas.icict.fiocruz.br/", "target": "_blank", "height": 40, "width": 116 },
-        { "file": "logo-icict", "to": "https://pcdas.icict.fiocruz.br/", "target": "_blank", "height": 40, "width": 116 },
-        { "file": "logo-pcdas", "to": "https://pcdas.icict.fiocruz.br/", "target": "_blank", "height": 40, "width": 72 },
-        { "file": "assets/images/imaginable.png", "isPng": true, "to": "https://www.imaginablefutures.com/", "target": "_blank", "height": 30, "width": 106 },
-        { "file": "assets/images/lemann.png", "isPng": true, "to": "https://fundacaolemann.org.br/", "target": "_blank", "height": 30, "width": 106 }
+        {
+          "file": "logo-Ilda",
+          "to": "https://idatosabiertos.org/",
+          "target": "_blank",
+          "height": 17,
+          "width": 52
+        },
+        {
+          "file": "logo_empatia",
+          "to": "https://www.empatia.la/",
+          "target": "_blank",
+          "height": 16,
+          "width": 87
+        },
+        {
+          "file": "logo-jurema",
+          "to": "https://www.jurema.la/",
+          "target": "_blank",
+          "height": 18,
+          "width": 80
+        },
+        {
+          "file": "logo-digitalocean",
+          "to": "https://www.digitalocean.com/",
+          "target": "_blank",
+          "height": 18,
+          "width": 110
+        },
+        {
+          "file": "logo-fiocruz",
+          "to": "https://pcdas.icict.fiocruz.br/",
+          "target": "_blank",
+          "height": 40,
+          "width": 116
+        },
+        {
+          "file": "logo-icict",
+          "to": "https://pcdas.icict.fiocruz.br/",
+          "target": "_blank",
+          "height": 40,
+          "width": 116
+        },
+        {
+          "file": "logo-pcdas",
+          "to": "https://pcdas.icict.fiocruz.br/",
+          "target": "_blank",
+          "height": 40,
+          "width": 72
+        },
+        {
+          "file": "assets/images/imaginable.png",
+          "isPng": true,
+          "to": "https://www.imaginablefutures.com/",
+          "target": "_blank",
+          "height": 30,
+          "width": 106
+        },
+        {
+          "file": "assets/images/lemann.png",
+          "isPng": true,
+          "to": "https://fundacaolemann.org.br/",
+          "target": "_blank",
+          "height": 30,
+          "width": 106
+        }
       ]
     }
   ]

--- a/src/assets/pages/home.json
+++ b/src/assets/pages/home.json
@@ -15,7 +15,7 @@
             "width": 50
           }
         },
-        "count": 359,
+        "count": null,
         "text": "Cidades já na plataforma"
       },
       {


### PR DESCRIPTION
**Português (BR)** | [English (US)](?quick_pull=1&template=PULL_REQUEST-en-US.md)

Como não temos um endpoint de count de cidades, basicamente o que fiz foi usar o endpoint de listagem de cidades. Eu consumo esse endpoint na home e na página de cidades-disponiveis, porém para evitar chamadas desnecessárias ao back, adicionei um cache usando shareReply, então se o usuário entrar na home e depois entrar em /cidades-disponiveis, só uma chamada será disparada, e vice-versa.

Também modifiquei o json do content no componente de home para 'mergear' esse dado dinâmico aos dados estáticos do json sem precisar modificar o HTML.

## Comunidade

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/okfn-brasil/querido-diario-frontend/blob/main/docs/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://github.com/okfn-brasil/querido-diario-comunidade/blob/main/.github/CODE_OF_CONDUCT.md).

## Tipo de alteração

* [ ] 🐞 Correção de problema
* [x] ✨ Melhoria ou nova funcionalidade
* [ ] 📰 Nova postagem no blog

## Issues relacionadas
Issues que são relacionadas a esta Pull Request.

#194 


## Validação

* [x] Validei a alteração no link gerado pelo bot da Netlify (Deploy Preview/Preview on mobile)
* [x] Validei o Layout responsivo (desktop/mobile) após a implementação
* [x] Verifiquei o registro do deploy (Latest deploy log) e nenhum novo alerta ou erro foi adicionado

## Documentação

* [ ] A documentação deste repositório foi atualizada (quando necessário).
* [ ] Esta alteração requer que a documentação externa seja atualizada.
