### PR TITLE
fix: Indicador das notificações desalinhado com o ícone

### DIFF
--- a/src/app/modules/components/notifications/notifications.component.sass
+++ b/src/app/modules/components/notifications/notifications.component.sass
@@ -1,6 +1,7 @@
 .mat-dialog-container
   padding: 0 0 0 15px !important
   box-shadow: none !important
+  margin-left: -1.7rem
 
 .mat-dialog-content
   padding: 0


### PR DESCRIPTION
**Português (BR)** | [English (US)](?quick_pull=1&template=PULL_REQUEST-en-US.md)

## Comunidade

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/okfn-brasil/querido-diario-frontend/blob/main/docs/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/codigo-de-conduta.html).

## Tipo de alteração

* [x] 🐞 Correção de problema
* [ ] ✨ Melhoria ou nova funcionalidade
* [ ] 📰 Nova postagem no blog

## Issues relacionadas
Issues que são relacionadas a esta Pull Request.

Resolve #197 

<!--
Considere abrir uma issue relacionada à alteração ou conversar com alguém para que seja aberta e assim termos mapeadas as alterações.

Caso esta Pull Request resolva uma ou mais issues existentes, vincule-as com uma palavra-chave para que ao ser mergeada, a issue seja fechada.

Ex.: Resolve #123

Mais informações: https://docs.github.com/pt/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Validação

* [x] Validei a alteração no link gerado pelo bot da Netlify (Deploy Preview/Preview on mobile)
* [x] Validei o Layout responsivo (desktop/mobile) após a implementação
* [x] Verifiquei o registro do deploy (Latest deploy log) e nenhum novo alerta ou erro foi adicionado

## Evidências
Anexe evidências do antes e do depois da alteração (quando necessário).

<!-- Você pode arrastar imagens para cá. -->

Antes:
<img width="1123" alt="Captura de Tela 2024-10-10 às 6 06 46 PM" src="https://github.com/user-attachments/assets/bef5a045-fd76-47fa-a435-9d893d68d49a">

Depois (safari):
<img width="1123" alt="Captura de Tela 2024-10-10 às 6 07 48 PM" src="https://github.com/user-attachments/assets/7ad6085f-8fa8-4a1a-9840-b9664979c5e6">

Depois (chrome):
<img width="1123" alt="Captura de Tela 2024-10-10 às 6 08 18 PM" src="https://github.com/user-attachments/assets/bef1f282-0ef7-413e-b034-d349450b5082">

Depois (Firefox):

<img width="1123" alt="Captura de Tela 2024-10-10 às 6 08 57 PM" src="https://github.com/user-attachments/assets/96de1533-55a4-42dc-816f-9ed39a7a1113">


## Documentação

* [ ] A documentação deste repositório foi atualizada (quando necessário).
* [ ] Esta alteração requer que a documentação externa seja atualizada.
