### PR TITLE
Fix #358: Home.component agora usa variavel atribuida ao inves do i18n

### DIFF
--- a/src/app/modules/pages/home/home.component.html
+++ b/src/app/modules/pages/home/home.component.html
@@ -17,7 +17,7 @@
     <app-container [gap]="34">
       <h1>{{ 'evolution.title' | translate }}</h1>
       <app-row layoutAlign="space-between" [flex]="true" [gap]="30">
-        <app-column *ngFor="let item of 'evolution.items' | translate">
+        <app-column *ngFor="let item of content.evolution.items">
           <app-row
             [gap]="24"
             layoutAlign="left"
@@ -30,7 +30,7 @@
           </app-row>
         </app-column>
       </app-row>
-      <ng-container *ngFor="let action of 'evolution.actions' | translate">
+      <ng-container *ngFor="let action of content.evolution.actions">
         <app-row class="evolution-link" [gap]="6">
           <a [routerLink]="action.to">
             {{ action.text }}

--- a/src/app/modules/pages/home/home.component.html
+++ b/src/app/modules/pages/home/home.component.html
@@ -17,20 +17,22 @@
     <app-container [gap]="34">
       <h1>{{ 'evolution.title' | translate }}</h1>
       <app-row layoutAlign="space-between" [flex]="true" [gap]="30">
-        <app-column *ngFor="let item of content.evolution.items">
+        <app-column *ngFor="let item of 'evolution.items' | translate; let index = index">
           <app-row
             [gap]="24"
             layoutAlign="left"
           >
             <app-icon [icon]="item.icon" class="evolution-icon"></app-icon>
             <app-column [gap]="16">
-              <span class="number">{{ item.count }}</span>
+              <span class="number">
+                {{ index === 0 ? content.evolution.items[0].count : item.count }}
+              </span>
               <p>{{ item.text }}</p>
             </app-column>
           </app-row>
         </app-column>
       </app-row>
-      <ng-container *ngFor="let action of content.evolution.actions">
+      <ng-container *ngFor="let action of 'evolution.actions' | translate">
         <app-row class="evolution-link" [gap]="6">
           <a [routerLink]="action.to">
             {{ action.text }}

--- a/src/assets/i18n/en/home.json
+++ b/src/assets/i18n/en/home.json
@@ -34,7 +34,7 @@
             "width": 50
           }
         },
-        "count": "700,000+",
+        "count": "850,000+",
         "height": 76,
         "width": 76,
         "text": "diaries available for search"


### PR DESCRIPTION
**Português (BR)** | [English (US)](?quick_pull=1&template=PULL_REQUEST-en-US.md)

## Comunidade

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/okfn-brasil/querido-diario-frontend/blob/main/docs/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/codigo-de-conduta.html).

## Tipo de alteração

* [x] 🐞 Correção de problema
* [ ] ✨ Melhoria ou nova funcionalidade
* [ ] 📰 Nova postagem no blog

## Issues relacionadas
Issues que são relacionadas a esta Pull Request.

Resolve #358
<!--
Considere abrir uma issue relacionada à alteração ou conversar com alguém para que seja aberta e assim termos mapeadas as alterações.

Caso esta Pull Request resolva uma ou mais issues existentes, vincule-as com uma palavra-chave para que ao ser mergeada, a issue seja fechada.

Ex.: Resolve #123

Mais informações: https://docs.github.com/pt/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Validação

* [ ] Validei a alteração no link gerado pelo bot da Netlify (Deploy Preview/Preview on mobile)
* [ ] Validei o Layout responsivo (desktop/mobile) após a implementação
* [ ] Verifiquei o registro do deploy (Latest deploy log) e nenhum novo alerta ou erro foi adicionado

## Evidências
Anexe evidências do antes e do depois da alteração (quando necessário).

Antes:
<img width="1768" height="350" alt="image" src="https://github.com/user-attachments/assets/de1abc68-42f3-454f-a0cd-d46a8aeabf78" />
Depois:
<img width="1737" height="343" alt="image" src="https://github.com/user-attachments/assets/a8fc6813-5d8e-4e29-ace9-6a3f9ddf6328" />


<!-- Você pode arrastar imagens para cá. -->

## Documentação

* [ ] A documentação deste repositório foi atualizada (quando necessário).
* [ ] Esta alteração requer que a documentação externa seja atualizada.
