### PR TITLE
Fix: volta a exibir dialog de notificações

### DIFF
--- a/src/app/modules/components/header/header.component.html
+++ b/src/app/modules/components/header/header.component.html
@@ -17,7 +17,7 @@
           </ng-template>
         </ng-container>
 
-        <a fxLayout="center" (click)="openNotifications()">
+        <a fxLayout="center" (click)="openNotifications()" #notification>
           <app-icon [icon]="notificationIcon"></app-icon>
         </a>
         <button (click)="openCaterseUrl()" class="btn">{{ 'header.buttons.support' | translate }}</button>

--- a/src/app/modules/components/header/header.component.ts
+++ b/src/app/modules/components/header/header.component.ts
@@ -107,6 +107,7 @@ export class HeaderComponent implements OnInit {
         top: '40px',
         left: `${left}px`,
       },
+      autoFocus: false,
     });
 
     this.modal.afterAllClosed.subscribe(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,20 @@
     enhanced-resolve "5.7.0"
     webpack-sources "2.2.0"
 
+"@ngx-translate/core@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@ngx-translate/core/-/core-13.0.0.tgz#60547cb8a0845a2a0abfde6b0bf5ec6516a63fd6"
+  integrity sha512-+tzEp8wlqEnw0Gc7jtVRAJ6RteUjXw6JJR4O65KlnxOmJrCGPI0xjV/lKRnQeU0w4i96PQs/jtpL921Wrb7PWg==
+  dependencies:
+    tslib "^2.0.0"
+
+"@ngx-translate/http-loader@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@ngx-translate/http-loader/-/http-loader-6.0.0.tgz#041393ab5753f50ecf64262d624703046b8c7570"
+  integrity sha512-LCekn6qCbeXWlhESCxU1rAbZz33WzDG0lI7Ig0pYC1o5YxJWrkU9y3Y4tNi+jakQ7R6YhTR2D3ox6APxDtA0wA==
+  dependencies:
+    tslib "^2.0.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"


### PR DESCRIPTION
**Português (BR)** | [English (US)](?quick_pull=1&template=PULL_REQUEST-en-US.md)

## Comunidade

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/okfn-brasil/querido-diario-frontend/blob/main/docs/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/codigo-de-conduta.html).

## Tipo de alteração

* [X] 🐞 Correção de problema
* [ ] ✨ Melhoria ou nova funcionalidade
* [ ] 📰 Nova postagem no blog

## Issues relacionadas
Resolve https://github.com/okfn-brasil/querido-diario-frontend/issues/364

Para correção, apenas voltei a referência #notifications da ViewChild no arquivo. Já estava lá antes, mas um PR posterior acabou pegando a versão antiga e [removeu por acidente essa parte](https://github.com/okfn-brasil/querido-diario-frontend/pull/322/changes#diff-777e01ec930a36d848d9c64a502f1b42b2d0e3a6bc268d85ce599b33cf0a4c9dR20). 

Aproveitei e adicionei autoFocus false na dialog. O padrão é ser true, mas com isso, ao clicar no sininho, a visualização não começa no primeiro item disponível, mas no primeiro link existente, que pode estar bem pra baixo (acho que no vídeo fica mais fácil de ver). 

Também commitei o yarn.lock com dependências que foram adicionadas [aqui](https://github.com/okfn-brasil/querido-diario-frontend/pull/322/changes#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R33-R34). 

## Validação

* [X] Validei a alteração no link gerado pelo bot da Netlify (Deploy Preview/Preview on mobile)
* [X] Validei o Layout responsivo (desktop/mobile) após a implementação
* [X] Verifiquei o registro do deploy (Latest deploy log) e nenhum novo alerta ou erro foi adicionado

## Evidências

Ao clicar no sininho, as notificações voltam a aparecer.

Aqui é o comportamento sem a inclusão do autoFocus: false:

https://github.com/user-attachments/assets/745fcad6-c211-4368-b13a-3230fcd4fa42

E aqui a correção (primeiro eu clico para abrir as notificações e depois dou um tab):

https://github.com/user-attachments/assets/0d8090fa-85c1-4100-bacb-ccc3c14a1278


## Documentação

* [ ] A documentação deste repositório foi atualizada (quando necessário).
* [ ] Esta alteração requer que a documentação externa seja atualizada.
