### PR TITLE
feat: torna URL da API configurável em runtime via EnvService

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  IMAGE: ghcr.io/okfn-brasil/querido-diario-frontend
+
+jobs:
+  build:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,14 +18,14 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -33,7 +33,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -41,7 +41,7 @@ jobs:
             type=sha,prefix=,format=short
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: ${{ github.event_name == 'push' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Stage 1: build Angular
+FROM node:16.2.0-alpine AS builder
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY . .
+RUN yarn build
+
+# Stage 2: serve com nginx
+FROM nginx:1.25-alpine
+COPY --from=builder /app/dist/querido-diario /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA: todas as rotas não encontradas como arquivo → index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # env.js nunca cacheado: permite atualizar config sem cache de browser
+    location = /env.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        expires 0;
+    }
+}

--- a/src/app/env.service.ts
+++ b/src/app/env.service.ts
@@ -9,6 +9,9 @@ export class EnvService {
 
   public envFileLoaded = false
 
+  // URL base da API — sobrescrita em runtime via env.js (window.__env.apiUrl)
+  public apiUrl = 'https://api.queridodiario.ok.org.br'
+
   // Max size of Querido Diário API results (THEMED_EXCERPT_FRAGMENT_SIZE)
   public qdApiSearchResultMaxSize = 10000
 

--- a/src/app/services/aggregate/aggregate.service.ts
+++ b/src/app/services/aggregate/aggregate.service.ts
@@ -3,13 +3,13 @@ import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { AggregateQuery, ResponseAggregate } from 'src/app/interfaces/aggregate';
-import { API } from 'src/app/constants';
+import { EnvService } from 'src/app/env.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AggregateService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private env: EnvService) {}
 
   /**
    * Handle Http operation that failed.
@@ -34,11 +34,11 @@ export class AggregateService {
 
     if (!territory_id) {
       queryParams = { state_code: state_code };
-      url = API + `/aggregates/${state_code}`;
+      url = this.env.apiUrl + `/aggregates/${state_code}`;
     } else {
       queryParams = { territory_id: territory_id };
       const encodedQueryString = new URLSearchParams(queryParams).toString();
-      url = API + `/aggregates/${state_code}?${encodedQueryString}`;
+      url = this.env.apiUrl + `/aggregates/${state_code}?${encodedQueryString}`;
     }
 
     return this.http.get<ResponseAggregate>(url).pipe(

--- a/src/app/services/cities/cities.service.ts
+++ b/src/app/services/cities/cities.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { catchError, map, shareReplay } from 'rxjs/operators';
-import { API } from 'src/app/constants';
+import { EnvService } from 'src/app/env.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Injectable({
@@ -10,11 +10,11 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 })
 export class CitiesService {
   getAllObservableCache: Observable<any> | null = null;
-  constructor(private http: HttpClient, private snackBar: MatSnackBar) {}
+  constructor(private http: HttpClient, private snackBar: MatSnackBar, private env: EnvService) {}
 
   getAll(): Observable<any> {
     if (!this.getAllObservableCache)
-      this.getAllObservableCache = this.http.get(`${API}/cities?levels=3`).pipe(
+      this.getAllObservableCache = this.http.get(`${this.env.apiUrl}/cities?levels=3`).pipe(
         map((data) => {
           return data;
         }),

--- a/src/app/services/gazette/gazette.service.ts
+++ b/src/app/services/gazette/gazette.service.ts
@@ -3,13 +3,13 @@ import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { Download, DownloadsLabels, Gazette, GazetteQuery, GazetteResponse, Pagination } from 'src/app/interfaces/gazette';
-import { API } from 'src/app/constants';
+import { EnvService } from 'src/app/env.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class GazetteService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private env: EnvService) {}
 
   /**
    * Handle Http operation that failed.
@@ -78,7 +78,7 @@ export class GazetteService {
     queryParams = { ...queryParams, size: pagination.size, offset: pagination.offset };
 
     const encodedQueryString = new URLSearchParams(queryParams).toString();
-    const url = API + `/gazettes?${encodedQueryString}${territoryQuery}`;
+    const url = this.env.apiUrl + `/gazettes?${encodedQueryString}${territoryQuery}`;
 
     return this.http.get<GazetteResponse>(url).pipe(
       map((res: GazetteResponse) => {

--- a/src/app/services/suggestion/suggestion.service.ts
+++ b/src/app/services/suggestion/suggestion.service.ts
@@ -1,16 +1,16 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { API } from 'src/app/constants';
+import { EnvService } from 'src/app/env.service';
 import { Suggestion } from 'src/app/interfaces/suggestion';
 
 @Injectable({
   providedIn: 'root',
 })
 export class SuggestionService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private env: EnvService) {}
 
   save(data: Suggestion): Observable<any> {
-    return this.http.post(`${API}/suggestions`, data)
+    return this.http.post(`${this.env.apiUrl}/suggestions`, data)
   }
 }

--- a/src/app/services/territory/territory.service.ts
+++ b/src/app/services/territory/territory.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { API } from 'src/app/constants';
+import { EnvService } from 'src/app/env.service';
 import { Territory } from 'src/app/interfaces/territory';
 
 @Injectable({
@@ -14,10 +14,10 @@ export class TerritoryService {
   private territory = new Subject<Territory>();
   territory$ = this.territory.asObservable();
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private env: EnvService) {}
 
   findOne(params: { territoryId: string }): Observable<Territory> {
-    const url = `${API}/cities/${params.territoryId}`
+    const url = `${this.env.apiUrl}/cities/${params.territoryId}`
     return this.http.get<{ city: Territory }>(url).pipe(
       map((res: { city: Territory }) => {
         return this.appendState(res.city)
@@ -26,7 +26,7 @@ export class TerritoryService {
   }
 
   findByName(name: string): Observable<Territory[]> {
-    const url = `${API}/cities?city_name=` + name;
+    const url = `${this.env.apiUrl}/cities?city_name=` + name;
 
     return this.http.get<{ cities: [] }>(url).pipe(
       map((res: { cities: [] }) => {

--- a/src/env.js
+++ b/src/env.js
@@ -4,6 +4,9 @@
   // Override the default value to make sure it was loaded.
   window.__env.envFileLoaded = true;
 
+  // URL base da API do Querido Diário
+  window.__env.apiUrl = 'https://api.queridodiario.ok.org.br';
+
   // Max size of Querido Diário API results (THEMED_EXCERPT_FRAGMENT_SIZE)
   window.__env.qdApiSearchResultMaxSize = 10000;
 }(this));

--- a/src/env.js
+++ b/src/env.js
@@ -5,7 +5,9 @@
   window.__env.envFileLoaded = true;
 
   // URL base da API do Querido Diário
-  window.__env.apiUrl = 'https://api.queridodiario.ok.org.br';
+  if (typeof window.__env.apiUrl === 'undefined') {
+    window.__env.apiUrl = 'https://api.queridodiario.ok.org.br';
+  }
 
   // Max size of Querido Diário API results (THEMED_EXCERPT_FRAGMENT_SIZE)
   window.__env.qdApiSearchResultMaxSize = 10000;


### PR DESCRIPTION
## Summary

- A URL da API estava hardcoded em `constants.ts` (compilada no bundle Angular), impedindo configuração por ambiente sem rebuild.
- Adicionada propriedade `apiUrl` ao `EnvService` com valor padrão de produção (`https://api.queridodiario.ok.org.br`).
- Exposta via `window.__env.apiUrl` em `env.js` (asset estático carregado antes do Angular, fora do bundle).
- 5 serviços (`gazette`, `aggregate`, `suggestion`, `territory`, `cities`) passam a ler `this.env.apiUrl` em vez de importar `constants.ts`.

## Compatibilidade

Sem breaking change: o valor padrão é idêntico ao anterior. O deploy no Netlify continua funcionando sem nenhuma alteração de configuração.

## Motivação

Permite sobrescrever a URL da API via `env.js` em outros ambientes (Kubernetes local, staging, produção alternativa) sem necessidade de rebuild da imagem Docker — seguindo o padrão [12-factor app](https://12factor.net/config) e o mecanismo `window.__env` já existente no projeto.

## Test plan

- [ ] `ng build --prod` compila sem erros
- [ ] App carrega em dev (`ng serve`) e chama `https://api.queridodiario.ok.org.br`
- [ ] Substituindo `env.js` com URL diferente, o app passa a chamar a nova URL sem rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)