### PR TITLE
fix: adiciona página 404 com meta tag noindex/nofollow

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -29,6 +29,7 @@ import { AboutComponent as AboutComponentEnUS } from './modules/pages/about-en_U
 import { TechComponent as TechComponentEnUS } from './modules/pages/tech-en_US/tech.component';
 import { PrivacyPolicyComponent as PrivacyPolicyComponentEnUS } from './modules/pages/privacy-policy-en_US/privacy-policy.component';
 import { RequestAnalysisFormComponent } from './modules/pages/area-education/request-analysis-form/request-analysis-form.component';
+import { NotFoundComponent } from './modules/pages/not-found/not-found.component';
 
 
 const routes: Routes = [
@@ -64,6 +65,7 @@ const routes: Routes = [
   { path: 'educacao/caso/:id', component: ReportDetailComponent },
   { path: 'educacao/redefinir-senha', component: PassResetComponent },
   { path: 'educacao/pedido-analise', component: RequestAnalysisFormComponent },
+  { path: '**', component: NotFoundComponent },
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -101,6 +101,7 @@ import { AggregateSearchComponent } from './modules/pages/aggregate-search/aggre
 import { AggregateComponent } from './modules/pages/aggregate/aggregate.component';
 import { GlossaryComponent } from './modules/pages/glossary/glossary.component';
 import { HomeComponent } from './modules/pages/home/home.component';
+import { NotFoundComponent } from './modules/pages/not-found/not-found.component';
 import {
   PrivacyPolicyComponent as PrivacyPolicyComponentEnUS,
 } from './modules/pages/privacy-policy-en_US/privacy-policy.component';
@@ -132,6 +133,7 @@ export function HttpLoaderFactory(http: HttpClient) {
     AboutComponent,
     UniversitiesComponent,
     PrivacyPolicyComponent,
+    NotFoundComponent,
     ComplaintComponent,
     AccessLevelsComponent,
     SupportComponent,

--- a/src/app/modules/pages/not-found/not-found.component.html
+++ b/src/app/modules/pages/not-found/not-found.component.html
@@ -1,0 +1,5 @@
+<div class="not-found-container">
+    <h1>404</h1>
+    <p>Ops! A página que você procura não existe ou foi movida.</p>
+    <button (click)="goHome()">Voltar para a página inicial</button>
+</div>

--- a/src/app/modules/pages/not-found/not-found.component.sass
+++ b/src/app/modules/pages/not-found/not-found.component.sass
@@ -1,0 +1,25 @@
+.not-found-container
+  display: flex
+  flex-direction: column
+  align-items: center
+  justify-content: center
+  text-align: center
+  padding: 4rem 1rem
+  color: white
+
+  h1
+    color: white
+
+  p
+    color: white
+
+  button
+    color: white
+    background-color: transparent
+    border: 1px solid white
+    padding: 0.5rem 1.5rem
+    border-radius: 4px
+    cursor: pointer
+
+    &:hover
+      background-color: rgba(255, 255, 255, 0.1)

--- a/src/app/modules/pages/not-found/not-found.component.spec.ts
+++ b/src/app/modules/pages/not-found/not-found.component.spec.ts
@@ -1,0 +1,68 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Meta, Title } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { NotFoundComponent } from './not-found.component';
+
+describe('NotFoundComponent', () => {
+  let component: NotFoundComponent;
+  let fixture: ComponentFixture<NotFoundComponent>;
+  let meta: Meta;
+  let title: Title;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NotFoundComponent],
+      imports: [RouterTestingModule],
+      providers: [Meta, Title]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NotFoundComponent);
+    component = fixture.componentInstance;
+    meta = TestBed.inject(Meta);
+    title = TestBed.inject(Title);
+    router = TestBed.inject(Router);
+  });
+
+  // Cenário 1: componente é criado com sucesso
+  it('deve criar o componente', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  // Cenário 2: meta tag robots noindex/nofollow é aplicada
+  it('deve adicionar a meta tag robots com noindex e nofollow', () => {
+    fixture.detectChanges();
+    const robotsTag = meta.getTag('name="robots"');
+    expect(robotsTag).toBeTruthy();
+    expect(robotsTag?.content).toBe('noindex, nofollow');
+  });
+
+  // Cenário 3: título da página é definido corretamente
+  it('deve definir o título da página como "Página não encontrada - Querido Diário"', () => {
+    fixture.detectChanges();
+    expect(title.getTitle()).toBe('Página não encontrada - Querido Diário');
+  });
+
+  // Cenário 4: botão navega para a home ao ser clicado
+  it('deve navegar para a rota inicial ao clicar no botão', () => {
+    fixture.detectChanges();
+    const navigateSpy = spyOn(router, 'navigate');
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+
+    expect(navigateSpy).toHaveBeenCalledWith(['/']);
+  });
+
+  // Cenário 5: conteúdo textual esperado aparece no template
+  it('deve exibir o texto "404" e a mensagem de erro', () => {
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    expect(compiled.querySelector('h1')?.textContent).toContain('404');
+    expect(compiled.textContent).toContain('não existe ou foi movida');
+  });
+});

--- a/src/app/modules/pages/not-found/not-found.component.ts
+++ b/src/app/modules/pages/not-found/not-found.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit } from '@angular/core';
+import { Meta, Title } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+
+@Component({
+    selector: 'app-not-found',
+    templateUrl: './not-found.component.html',
+    styleUrls: ['./not-found.component.sass']
+})
+export class NotFoundComponent implements OnInit {
+
+    constructor(
+        private meta: Meta,
+        private title: Title,
+        private router: Router
+    ) { }
+
+    ngOnInit(): void {
+        this.meta.updateTag({ name: 'robots', content: 'noindex, nofollow' });
+        this.title.setTitle('Página não encontrada - Querido Diário');
+    }
+
+    goHome(): void {
+        this.router.navigate(['/']);
+    }
+}


### PR DESCRIPTION
**Português (BR)** | [English (US)](?quick_pull=1&template=PULL_REQUEST-en-US.md)

## Comunidade

* [x] Eu li e segui o [Guia de Contribuição](https://github.com/okfn-brasil/querido-diario-frontend/blob/main/docs/CONTRIBUTING.md).
* [x] Eu li e segui o [Código de Conduta](https://docs.queridodiario.ok.org.br/pt-br/latest/contribuindo/codigo-de-conduta.html).

## Tipo de alteração

* [x] 🐞 Correção de problema
* [ ] ✨ Melhoria ou nova funcionalidade
* [ ] 📰 Nova postagem no blog

## Issues relacionadas

Resolve #369

Relacionado à issue #258 (que originou a discussão sobre tratamento de
rotas inválidas) e ao PR #367 (que corrigiu parte do status das rotas).

## Validação

* [ ] Validei a alteração no link gerado pelo bot da Netlify (Deploy Preview/Preview on mobile)
* [x] Validei o Layout responsivo (desktop/mobile) após a implementação
* [ ] Verifiquei o registro do deploy (Latest deploy log) e nenhum novo alerta ou erro foi adicionado

## Evidências

**Antes (produção, comportamento atual):**
Ao acessar uma URL inválida no site em produção, a página carrega em
branco (sem mensagem de erro) e o servidor retorna status HTTP 200
("soft 404"), permitindo indexação incorreta por buscadores.

<img width="1904" height="1056" alt="producao-status-200" src="https://github.com/user-attachments/assets/447057dc-0e37-4166-8270-7e3ee73b110c" />

<img width="1913" height="1073" alt="problema" src="https://github.com/user-attachments/assets/4c8d6841-27a7-43ad-8878-f7548e066c70" />

**Depois (implementação local, branch desta PR):**
A mesma URL passa a exibir uma página 404 customizada, com mensagem
clara e botão de retorno à página inicial. A meta tag
`<meta name="robots" content="noindex, nofollow">` é aplicada
dinamicamente no `<head>`, evitando a indexação da URL inválida.
<img width="1917" height="1075" alt="solucao" src="https://github.com/user-attachments/assets/42b06e4f-6ac5-44b8-8555-9463710adce2" />

<img width="1419" height="665" alt="local-meta-tag png" src="https://github.com/user-attachments/assets/ea909f28-4d76-4e8f-b935-e3f3b04ae05f" />

## Documentação

* [ ] A documentação deste repositório foi atualizada (quando necessário).
* [ ] Esta alteração requer que a documentação externa seja atualizada.